### PR TITLE
NGSTACK-816 show frontent urls by siteaccess

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '[0-9].[0-9]+'
+  pull_request: ~
+
+jobs:
+  tests:
+    name: ${{ matrix.php }} / ${{ matrix.phpunit }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1']
+        phpunit: ['phpunit.xml']
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - run: composer --version
+      - run: composer validate --strict
+
+      - run: composer update --prefer-dist
+
+      - run: vendor/bin/phpunit -c ${{ matrix.phpunit }} --colors=always

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This package enhances the visibility of Content URLs by Siteaccess. URLs can be 
 The package distinguishes between two types of URLs:
 
 1. **Siteaccess URLs** that reside within the configured Siteaccess Content tree.
-2. **Siteaccess URLs** that exist outside of the configured Siteaccess Content tree.
+2. **Siteaccess URLs** that exist outside the configured Siteaccess Content tree.
 
 By default, the overview of URLs outside the configured Content tree is disabled.
 To display these URLs, you need to enable this option in your configuration:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ This package enhances the visibility of Content URLs by Siteaccess. URLs can be 
 
 The package distinguishes between two types of URLs:
 
-1. **Content Tree URLs**: URLs that reside within the configured Siteaccess Content tree.
-2. **External URLs**: URLs that exist outside of the configured Siteaccess Content tree.
+1. **Siteaccess URLs** that reside within the configured Siteaccess Content tree.
+2. **Siteaccess URLs** that exist outside of the configured Siteaccess Content tree.
 
-By default, the overview of External URLs is hidden. To enable the display of these URLs, set the following parameter in your configuration:
+By default, the overview of URLs outside of the configured Content tree is hidden.
+To enable the display of these URLs, set the following parameter in your configuration:
 
 ```yaml
 netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls: true

--- a/README.md
+++ b/README.md
@@ -27,4 +27,21 @@ netgen_ibexa_admin_ui_extra:
     resource: '@NetgenIbexaAdminUIExtraBundle/Resources/config/routing.yaml'
 ```
 
+Content URLs by Siteaccess
+--------------------------
+
+This package enhances the visibility of Content URLs by Siteaccess. URLs can be viewed in the administration interface under the **URL** tab within the Content view.
+
+The package distinguishes between two types of URLs:
+
+1. **Content Tree URLs**: URLs that reside within the configured Siteaccess Content tree.
+2. **External URLs**: URLs that exist outside of the configured Siteaccess Content tree.
+
+By default, the overview of External URLs is hidden. To enable the display of these URLs, set the following parameter in your configuration:
+
+```yaml
+netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls: true
+
+
+
 Licensed under [GPLv2](LICENSE)

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ The package distinguishes between two types of URLs:
 1. **Siteaccess URLs** that reside within the configured Siteaccess Content tree.
 2. **Siteaccess URLs** that exist outside of the configured Siteaccess Content tree.
 
-By default, the overview of URLs outside of the configured Content tree is hidden.
-To enable the display of these URLs, set the following parameter in your configuration:
+By default, the overview of URLs outside the configured Content tree is disabled.
+To display these URLs, you need to enable this option in your configuration:
 
 ```yaml
-netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls: true
+netgen_ibexa_admin_ui_extra:
+    show_siteaccess_urls_outside_configured_content_tree_root: true
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ By default, the overview of External URLs is hidden. To enable the display of th
 
 ```yaml
 netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls: true
-
+```
 
 
 Licensed under [GPLv2](LICENSE)

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ final class Configuration implements ConfigurationInterface
                 ->children()
                     ->booleanNode('show_siteaccess_urls_outside_configured_content_tree_root')
                         ->defaultFalse()
-                        ->info("Show Siteaccess URLs outside of the configured Content tree root in administration's URL tab")
+                        ->info("Show Siteaccess URLs outside the configured Content tree root in administration's URL tab")
                     ->end()
                 ?->end();
     }

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaAdminUIExtraBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    private string $rootNodeName;
+
+    public function __construct(string $rootNodeName)
+    {
+        $this->rootNodeName = $rootNodeName;
+    }
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder($this->rootNodeName);
+        $rootNode = $treeBuilder->getRootNode();
+
+        $this->addShowExternalSiteaccessUrls($rootNode);
+
+        return $treeBuilder;
+    }
+
+    private function addShowExternalSiteaccessUrls(ArrayNodeDefinition $nodeDefinition): void
+    {
+        $nodeDefinition
+            ->treatFalseLike(['enabled' => false])
+            ->treatTrueLike(['enabled' => true])
+            ->treatNullLike(['enabled' => false])
+                ->children()
+                    ->booleanNode('show_external_siteaccess_urls')
+                        ->defaultFalse()
+                    ->end()
+                ?->end();
+    }
+}

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -34,8 +34,9 @@ final class Configuration implements ConfigurationInterface
             ->treatTrueLike(['enabled' => true])
             ->treatNullLike(['enabled' => false])
                 ->children()
-                    ->booleanNode('show_external_siteaccess_urls')
+                    ->booleanNode('show_siteaccess_urls_outside_configured_content_tree_root')
                         ->defaultFalse()
+                        ->info("Show Siteaccess URLs outside of the configured Content tree root in administration's URL tab")
                     ->end()
                 ?->end();
     }

--- a/bundle/DependencyInjection/NetgenIbexaAdminUIExtraExtension.php
+++ b/bundle/DependencyInjection/NetgenIbexaAdminUIExtraExtension.php
@@ -19,6 +19,16 @@ use function file_get_contents;
 
 final class NetgenIbexaAdminUIExtraExtension extends Extension implements PrependExtensionInterface
 {
+    public function getAlias(): string
+    {
+        return 'netgen_ibexa_admin_ui_extra';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
+    {
+        return new Configuration($this->getAlias());
+    }
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $locator = new FileLocator(__DIR__ . '/../Resources/config');
@@ -33,6 +43,9 @@ final class NetgenIbexaAdminUIExtraExtension extends Extension implements Prepen
         );
 
         $loader->load('services/*.yaml', 'glob');
+        $loader->load('default_settings.yaml');
+
+        $this->processExtensionConfiguration($configs, $container);
     }
 
     public function prepend(ContainerBuilder $container): void
@@ -47,5 +60,23 @@ final class NetgenIbexaAdminUIExtraExtension extends Extension implements Prepen
             $container->prependExtensionConfig($extensionName, $config);
             $container->addResource(new FileResource($configFile));
         }
+    }
+
+    private function processExtensionConfiguration(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = $this->getConfiguration($configs, $container);
+        $configuration = $this->processConfiguration($configuration, $configs);
+
+        $this->processShowExternalSiteaccessUrlsConfiguration($configuration, $container);
+    }
+
+    private function processShowExternalSiteaccessUrlsConfiguration(
+        array $configuration,
+        ContainerBuilder $container,
+    ): void {
+        $container->setParameter(
+            'netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls',
+            $configuration['show_external_siteaccess_urls'],
+        );
     }
 }

--- a/bundle/DependencyInjection/NetgenIbexaAdminUIExtraExtension.php
+++ b/bundle/DependencyInjection/NetgenIbexaAdminUIExtraExtension.php
@@ -67,16 +67,16 @@ final class NetgenIbexaAdminUIExtraExtension extends Extension implements Prepen
         $configuration = $this->getConfiguration($configs, $container);
         $configuration = $this->processConfiguration($configuration, $configs);
 
-        $this->processShowExternalSiteaccessUrlsConfiguration($configuration, $container);
+        $this->processShowSiteaccessOutsideConfiguredContentTreeRootConfiguration($configuration, $container);
     }
 
-    private function processShowExternalSiteaccessUrlsConfiguration(
+    private function processShowSiteaccessOutsideConfiguredContentTreeRootConfiguration(
         array $configuration,
         ContainerBuilder $container,
     ): void {
         $container->setParameter(
-            'netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls',
-            $configuration['show_external_siteaccess_urls'],
+            'netgen_ibexa_admin_ui_extra.show_siteaccess_urls_outside_configured_content_tree_root',
+            $configuration['show_siteaccess_urls_outside_configured_content_tree_root'],
         );
     }
 }

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -1,2 +1,2 @@
 parameters:
-    netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls: false
+    netgen_ibexa_admin_ui_extra.show_siteaccess_urls_outside_configured_content_tree_root: false

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -1,0 +1,2 @@
+parameters:
+    netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls: false

--- a/bundle/Resources/config/services/tabs.yaml
+++ b/bundle/Resources/config/services/tabs.yaml
@@ -18,6 +18,7 @@ services:
             - '@router'
             - '@ibexa.config.resolver'
             - '%ibexa.site_access.list%'
+            - '%netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls%'
             - '@twig'
             - '@translator'
             - '@event_dispatcher'

--- a/bundle/Resources/config/services/tabs.yaml
+++ b/bundle/Resources/config/services/tabs.yaml
@@ -18,7 +18,7 @@ services:
             - '@router'
             - '@ibexa.config.resolver'
             - '%ibexa.site_access.list%'
-            - '%netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls%'
+            - '%netgen_ibexa_admin_ui_extra.show_siteaccess_urls_outside_configured_content_tree_root%'
             - '@twig'
             - '@translator'
             - '@event_dispatcher'

--- a/bundle/Resources/config/services/tabs.yaml
+++ b/bundle/Resources/config/services/tabs.yaml
@@ -9,3 +9,15 @@ services:
             - '@twig'
             - '@translator'
             - '@event_dispatcher'
+
+    Netgen\Bundle\IbexaAdminUIExtraBundle\Tab\LocationView\UrlsTab:
+        decorates: Ibexa\AdminUi\Tab\LocationView\UrlsTab
+        decoration_inner_name: UrlsTab.inner
+        arguments:
+            - '@UrlsTab.inner'
+            - '@router'
+            - '@ibexa.config.resolver'
+            - '%ibexa.site_access.list%'
+            - '@twig'
+            - '@translator'
+            - '@event_dispatcher'

--- a/bundle/Resources/translations/ibexa_content_url.en.yaml
+++ b/bundle/Resources/translations/ibexa_content_url.en.yaml
@@ -1,0 +1,5 @@
+tab.urls.siteaccess.headline.content_tree: 'Content tree URLs (inside configured Siteaccess Content tree)'
+tab.urls.siteaccess.headline.external: 'External URLs (outside configured Siteaccess Content tree)'
+tab.urls.siteaccess: 'Siteaccess'
+tab.urls.no_siteaccess_urls: 'This item has no Siteacess URLs.'
+tab.urls.url: 'URL'

--- a/bundle/Resources/translations/ibexa_content_url.en.yaml
+++ b/bundle/Resources/translations/ibexa_content_url.en.yaml
@@ -1,5 +1,5 @@
 tab.urls.siteaccess.headline.siteaccess_urls: 'Siteaccess URLs'
-tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root: 'Siteaccess URLs outside of the configured Content tree root'
+tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root: 'Siteaccess URLs outside the configured Content tree root'
 tab.urls.siteaccess: 'Siteaccess'
 tab.urls.no_siteaccess_urls: 'This item has no Siteacess URLs.'
 tab.urls.url: 'URL'

--- a/bundle/Resources/translations/ibexa_content_url.en.yaml
+++ b/bundle/Resources/translations/ibexa_content_url.en.yaml
@@ -1,5 +1,5 @@
-tab.urls.siteaccess.headline.content_tree: 'Content tree URLs (inside configured Siteaccess Content tree)'
-tab.urls.siteaccess.headline.external: 'External URLs (outside configured Siteaccess Content tree)'
+tab.urls.siteaccess.headline.siteaccess_urls: 'Siteaccess URLs'
+tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root: 'Siteaccess URLs outside of the configured Content tree root'
 tab.urls.siteaccess: 'Siteaccess'
 tab.urls.no_siteaccess_urls: 'This item has no Siteacess URLs.'
 tab.urls.url: 'URL'

--- a/bundle/Resources/views/themes/ngadmin/content/tab/url/siteaccess_urls_table.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/url/siteaccess_urls_table.html.twig
@@ -1,0 +1,38 @@
+{% trans_default_domain 'ibexa_content_url' %}
+
+{% set body_rows = [] %}
+{% if siteaccess_urls|length > 0 %}
+    {% for siteaccess, siteaccess_url in siteaccess_urls %}
+        {% set body_row_cols = [] %}
+
+        {% set col_raw %}
+            <a href="{{ siteaccess_url }}">{{ siteaccess_url }}</a>
+        {% endset %}
+
+        {% set body_row_cols = body_row_cols|merge([{
+            content: col_raw,
+            raw: true,
+        }]) %}
+
+        {% set col_raw %}
+                {{ siteaccess }}
+        {% endset %}
+
+        {% set body_row_cols = body_row_cols|merge([{
+            content: col_raw,
+            raw: true,
+        }]) %}
+
+        {% set body_rows = body_rows|merge([{ cols: body_row_cols }]) %}
+    {% endfor %}
+{% endif %}
+
+{% include '@ibexadesign/ui/component/table/table.html.twig' with {
+    headline: headline,
+    head_cols: [
+        { content: 'tab.urls.url'|trans|desc('URL') },
+        { content: 'tab.urls.siteaccess'|trans|desc('Siteaccess') },
+    ],
+    body_rows,
+    empty_table_info_text: 'tab.urls.no_siteaccess_urls'|trans|desc('This item has no siteacess URLs.'),
+} %}

--- a/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
@@ -1,16 +1,16 @@
 {% trans_default_domain 'ibexa_content_url' %}
 
 {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
-    headline:'tab.urls.siteaccess.headline.content_tree'|trans|desc
-        ('Content tree URLs (inside configured Siteaccess Content tree)'),
+    headline:'tab.urls.siteaccess.headline.siteaccess_urls'|trans|desc
+        ('Siteaccess URLs'),
     siteaccess_urls: content_tree_urls,
 } only %}
 
 {% if show_external_urls %}
     {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
         headline:
-        'tab.urls.siteaccess.headline.external'|trans|desc
-            ('External URLs (outside configured Siteaccess Content tree)'),
+        'tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root'|trans|desc
+            ('Siteaccess URLs outside of the configured Content tree root'),
         siteaccess_urls: external_urls,
     } only %}
 {% endif %}

--- a/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
@@ -6,11 +6,14 @@
     siteaccess_urls: content_tree_urls,
 } only %}
 
-{% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
-    headline:
-    'tab.urls.siteaccess.headline.external'|trans|desc
-        ('External URLs (outside configured Siteaccess Content tree)'),
-    siteaccess_urls: external_urls,
-} only %}
+{% if show_external_urls %}
+    {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
+        headline:
+        'tab.urls.siteaccess.headline.external'|trans|desc
+            ('External URLs (outside configured Siteaccess Content tree)'),
+        siteaccess_urls: external_urls,
+    } only %}
+{% endif %}
+
 
 {% include '@admin/content/tab/urls.html.twig' %}

--- a/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
@@ -10,7 +10,7 @@
     {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
         headline:
         'tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root'|trans|desc
-            ('Siteaccess URLs outside of the configured Content tree root'),
+            ('Siteaccess URLs outside the configured Content tree root'),
         siteaccess_urls: siteaccess_urls_outside_configured_content_tree_root,
     } only %}
 {% endif %}

--- a/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
@@ -3,17 +3,16 @@
 {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
     headline:'tab.urls.siteaccess.headline.siteaccess_urls'|trans|desc
         ('Siteaccess URLs'),
-    siteaccess_urls: content_tree_urls,
+    siteaccess_urls: siteaccess_urls,
 } only %}
 
-{% if show_external_urls %}
+{% if show_siteaccess_urls_outside_configured_content_tree_root %}
     {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
         headline:
         'tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root'|trans|desc
             ('Siteaccess URLs outside of the configured Content tree root'),
-        siteaccess_urls: external_urls,
+        siteaccess_urls: siteaccess_urls_outside_configured_content_tree_root,
     } only %}
 {% endif %}
-
 
 {% include '@admin/content/tab/urls.html.twig' %}

--- a/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
@@ -1,0 +1,16 @@
+{% trans_default_domain 'ibexa_content_url' %}
+
+{% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
+    headline:'tab.urls.siteaccess.headline.content_tree'|trans|desc
+        ('Content tree URLs (inside configured Siteaccess Content tree)'),
+    siteaccess_urls: content_tree_urls,
+} only %}
+
+{% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
+    headline:
+    'tab.urls.siteaccess.headline.external'|trans|desc
+        ('External URLs (outside configured Siteaccess Content tree)'),
+    siteaccess_urls: external_urls,
+} only %}
+
+{% include '@admin/content/tab/urls.html.twig' %}

--- a/bundle/Tab/LocationView/UrlsTab.php
+++ b/bundle/Tab/LocationView/UrlsTab.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\IbexaAdminUIExtraBundle\Tab\LocationView;
+
+use Ibexa\AdminUi\Tab\LocationView\UrlsTab as IbexaUrlsTab;
+use Ibexa\Contracts\AdminUi\Tab\AbstractEventDispatchingTab;
+use Ibexa\Contracts\AdminUi\Tab\OrderedTabInterface;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+use function array_search;
+use function preg_match;
+
+final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInterface
+{
+    private const SYSTEM_URL_REGEX_PATTERN = '#/view/content/\d+/full/\d+/\d+$#';
+
+    public function __construct(
+        private readonly IbexaUrlsTab $inner,
+        private readonly RouterInterface $router,
+        private readonly ConfigResolverInterface $configResolver,
+        private readonly array $siteaccessList,
+        Environment $twig,
+        TranslatorInterface $translator,
+        EventDispatcherInterface $eventDispatcher,
+    ) {
+        parent::__construct($twig, $translator, $eventDispatcher);
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->inner->getIdentifier();
+    }
+
+    public function getName(): string
+    {
+        return $this->inner->getName();
+    }
+
+    public function getOrder(): int
+    {
+        return $this->inner->getOrder();
+    }
+
+    public function getTemplate(): string
+    {
+        return $this->inner->getTemplate();
+    }
+
+    public function getTemplateParameters(array $contextParameters = []): array
+    {
+        $contentTreeUrls = [];
+        $externalUrls = [];
+
+        /** @var Location $location */
+        $location = $contextParameters['location'];
+
+        $locationPath = $location->path;
+        foreach ($this->siteaccessList as $siteaccess) {
+            $rootLocationId = $this->configResolver->getParameter(
+                'content.tree_root.location_id',
+                null,
+                $siteaccess,
+            );
+
+            $url = $this->router->generate(
+                'ibexa.url.alias',
+                [
+                    'locationId' => $location->id,
+                    'siteaccess' => $siteaccess,
+                ],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+
+            // checks if the url matches invalid system url format
+            if (preg_match(self::SYSTEM_URL_REGEX_PATTERN, $url)) {
+                continue;
+            }
+
+            $locationIdIndex = array_search((string) $location->id, $locationPath, true);
+            $rootLocationIdIndex = array_search((string) $rootLocationId, $locationPath, true);
+
+            // checks if the url is inside configured siteaccess content tree
+            if ($locationIdIndex !== false && $rootLocationIdIndex !== false && $rootLocationIdIndex <= $locationIdIndex) {
+                $contentTreeUrls[$siteaccess] = $url;
+            } else {
+                $externalUrls[$siteaccess] = $url;
+            }
+        }
+
+        $parameters = [
+            'content_tree_urls' => $contentTreeUrls,
+            'external_urls' => $externalUrls,
+        ];
+
+        $parentParameters = $this->inner->getTemplateParameters($contextParameters);
+
+        return $parentParameters + $parameters;
+    }
+}

--- a/bundle/Tab/LocationView/UrlsTab.php
+++ b/bundle/Tab/LocationView/UrlsTab.php
@@ -27,6 +27,7 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
         private readonly RouterInterface $router,
         private readonly ConfigResolverInterface $configResolver,
         private readonly array $siteaccessList,
+        private readonly bool $showExternalSiteaccessUrls,
         Environment $twig,
         TranslatorInterface $translator,
         EventDispatcherInterface $eventDispatcher,
@@ -97,6 +98,7 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
         $parameters = [
             'content_tree_urls' => $contentTreeUrls,
             'external_urls' => $externalUrls,
+            'show_external_urls' => $this->showExternalSiteaccessUrls,
         ];
 
         $parentParameters = $this->inner->getTemplateParameters($contextParameters);

--- a/bundle/Tab/LocationView/UrlsTab.php
+++ b/bundle/Tab/LocationView/UrlsTab.php
@@ -59,17 +59,11 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
         $contentTreeUrls = [];
         $externalUrls = [];
 
-        /** @var Location $location */
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
         $location = $contextParameters['location'];
 
         $locationPath = $location->path;
         foreach ($this->siteaccessList as $siteaccess) {
-            $rootLocationId = $this->configResolver->getParameter(
-                'content.tree_root.location_id',
-                null,
-                $siteaccess,
-            );
-
             $url = $this->router->generate(
                 'ibexa.url.alias',
                 [
@@ -85,6 +79,11 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
             }
 
             $locationIdIndex = array_search((string) $location->id, $locationPath, true);
+            $rootLocationId = $this->configResolver->getParameter(
+                'content.tree_root.location_id',
+                null,
+                $siteaccess,
+            );
             $rootLocationIdIndex = array_search((string) $rootLocationId, $locationPath, true);
 
             // checks if the url is inside configured siteaccess content tree

--- a/bundle/Tab/LocationView/UrlsTab.php
+++ b/bundle/Tab/LocationView/UrlsTab.php
@@ -27,7 +27,7 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
         private readonly RouterInterface $router,
         private readonly ConfigResolverInterface $configResolver,
         private readonly array $siteaccessList,
-        private readonly bool $showExternalSiteaccessUrls,
+        private readonly bool $showSiteaccessUrlsOutsideConfiguredContentTreeRoot,
         Environment $twig,
         TranslatorInterface $translator,
         EventDispatcherInterface $eventDispatcher,
@@ -57,8 +57,8 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
 
     public function getTemplateParameters(array $contextParameters = []): array
     {
-        $contentTreeUrls = [];
-        $externalUrls = [];
+        $siteaccessUrls = [];
+        $siteaccessUrlsOutsideConfiguredContentTreeRoot = [];
 
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
         $location = $contextParameters['location'];
@@ -89,16 +89,16 @@ final class UrlsTab extends AbstractEventDispatchingTab implements OrderedTabInt
 
             // checks if the url is inside configured siteaccess content tree
             if ($locationIdIndex !== false && $rootLocationIdIndex !== false && $rootLocationIdIndex <= $locationIdIndex) {
-                $contentTreeUrls[$siteaccess] = $url;
+                $siteaccessUrls[$siteaccess] = $url;
             } else {
-                $externalUrls[$siteaccess] = $url;
+                $siteaccessUrlsOutsideConfiguredContentTreeRoot[$siteaccess] = $url;
             }
         }
 
         $parameters = [
-            'content_tree_urls' => $contentTreeUrls,
-            'external_urls' => $externalUrls,
-            'show_external_urls' => $this->showExternalSiteaccessUrls,
+            'siteaccess_urls' => $siteaccessUrls,
+            'siteaccess_urls_outside_configured_content_tree_root' => $siteaccessUrlsOutsideConfiguredContentTreeRoot,
+            'show_siteaccess_urls_outside_configured_content_tree_root' => $this->showSiteaccessUrlsOutsideConfiguredContentTreeRoot,
         ];
 
         $parentParameters = $this->inner->getTemplateParameters($contextParameters);

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,18 @@
     },
     "require-dev": {
         "netgen/ibexa-site-api": "^6.1",
-        "ibexa/graphql": "^4.5"
+        "ibexa/graphql": "^4.5",
+        "phpunit/phpunit": "^10",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1"
     },
     "autoload": {
         "psr-4": {
             "Netgen\\Bundle\\IbexaAdminUIExtraBundle\\": "bundle"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Netgen\\IbexaAdminUIExtra\\Tests\\": "tests/bundle"
         }
     },
     "extra": {
@@ -29,5 +36,8 @@
     },
     "config": {
         "allow-plugins": false
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit --colors=always"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Dependency injection unit tests">
+            <directory suffix="Test.php">./tests/bundle/DependencyInjection</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bundle/DependencyInjection/NetgenIbexaAdminUIExtraTest.php
+++ b/tests/bundle/DependencyInjection/NetgenIbexaAdminUIExtraTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\IbexaAdminUIExtra\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Netgen\Bundle\IbexaAdminUIExtraBundle\DependencyInjection\NetgenIbexaAdminUIExtraExtension;
+
+final class NetgenIbexaAdminUIExtraTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setParameter('kernel.bundles', []);
+    }
+
+    public static function provideDefaultConfigurationCases(): iterable
+    {
+        return [
+            [
+                [],
+            ],
+            [
+                [
+                    'show_external_siteaccess_urls' => false,
+                ],
+            ],
+        ];
+    }
+
+    public static function provideShowExternalSiteaccessUrlsConfigurationCases(): iterable
+    {
+        return [
+            [
+                [
+                    'show_external_siteaccess_urls' => false,
+                ],
+                false,
+            ],
+            [
+                [
+                    'show_external_siteaccess_urls' => true,
+                ],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDefaultConfigurationCases
+     */
+    public function testDefaultConfiguration(array $configuration): void
+    {
+        $this->load($configuration);
+
+        $this->assertContainerBuilderHasParameter(
+            'netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls',
+            false,
+        );
+    }
+
+    /**
+     * @dataProvider provideShowExternalSiteaccessUrlsConfigurationCases
+     */
+    public function testShowExternalSiteaccessUrlsConfiguration(array $configuration, bool $expectedParameterValue): void
+    {
+        $this->load($configuration);
+
+        $this->assertContainerBuilderHasParameter(
+            'netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls',
+            $expectedParameterValue,
+        );
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new NetgenIbexaAdminUIExtraExtension(),
+        ];
+    }
+}

--- a/tests/bundle/DependencyInjection/NetgenIbexaAdminUIExtraTest.php
+++ b/tests/bundle/DependencyInjection/NetgenIbexaAdminUIExtraTest.php
@@ -24,7 +24,7 @@ final class NetgenIbexaAdminUIExtraTest extends AbstractExtensionTestCase
             ],
             [
                 [
-                    'show_external_siteaccess_urls' => false,
+                    'show_siteaccess_urls_outside_configured_content_tree_root' => false,
                 ],
             ],
         ];
@@ -35,13 +35,13 @@ final class NetgenIbexaAdminUIExtraTest extends AbstractExtensionTestCase
         return [
             [
                 [
-                    'show_external_siteaccess_urls' => false,
+                    'show_siteaccess_urls_outside_configured_content_tree_root' => false,
                 ],
                 false,
             ],
             [
                 [
-                    'show_external_siteaccess_urls' => true,
+                    'show_siteaccess_urls_outside_configured_content_tree_root' => true,
                 ],
                 true,
             ],
@@ -56,7 +56,7 @@ final class NetgenIbexaAdminUIExtraTest extends AbstractExtensionTestCase
         $this->load($configuration);
 
         $this->assertContainerBuilderHasParameter(
-            'netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls',
+            'netgen_ibexa_admin_ui_extra.show_siteaccess_urls_outside_configured_content_tree_root',
             false,
         );
     }
@@ -69,7 +69,7 @@ final class NetgenIbexaAdminUIExtraTest extends AbstractExtensionTestCase
         $this->load($configuration);
 
         $this->assertContainerBuilderHasParameter(
-            'netgen_ibexa_admin_ui_extra.show_external_siteaccess_urls',
+            'netgen_ibexa_admin_ui_extra.show_siteaccess_urls_outside_configured_content_tree_root',
             $expectedParameterValue,
         );
     }


### PR DESCRIPTION
https://netgen.atlassian.net/browse/NGSTACK-816
![Screenshot from 2024-08-16 12-07-32](https://github.com/user-attachments/assets/aafa5394-13f8-4677-a6e5-333a33bc933f)
![Screenshot from 2024-08-16 12-08-05](https://github.com/user-attachments/assets/116c075f-b5c6-4ed3-b2d2-e3e9baed18ca)
I added two tables to the URL tab in ibexa admin interface. 
First table contains generated frontend URLs for locations that are inside configured siteacces content tree, second one contains external URLs. Logic for that is in UrlsTab, as well as checking if generated URL matches invalid system url format. If it matches, it does not go inside any of the tables.  