### PR TITLE
Add default values to variables and check if set before including additional templates

### DIFF
--- a/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/tab/urls.html.twig
@@ -1,12 +1,16 @@
 {% trans_default_domain 'ibexa_content_url' %}
 
-{% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
-    headline:'tab.urls.siteaccess.headline.siteaccess_urls'|trans|desc
-        ('Siteaccess URLs'),
-    siteaccess_urls: siteaccess_urls,
-} only %}
+{% if siteaccess_urls|default([]) is not empty %}
+    {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
+        headline:'tab.urls.siteaccess.headline.siteaccess_urls'|trans|desc
+            ('Siteaccess URLs'),
+        siteaccess_urls: siteaccess_urls,
+    } only %}
+{% endif %}
 
-{% if show_siteaccess_urls_outside_configured_content_tree_root %}
+{% if show_siteaccess_urls_outside_configured_content_tree_root|default(false) == true
+    and siteaccess_urls_outside_configured_content_tree_root|default([]) is not empty
+%}
     {% include '@ibexadesign/content/tab/url/siteaccess_urls_table.html.twig' with {
         headline:
         'tab.urls.siteaccess.headline.siteaccess_urls.outside_configured_content_tree_root'|trans|desc


### PR DESCRIPTION
Some tabs in the admin UI, like URL tab, are extended (not decorated) by other Ibexa enterprise packages.
We are only decorating the location view URL tab, but adding our design ngadminui on top of adminui will use our template instead of the original one, which is in turn again reused in extended tab handlers.

If our decorator is not applied, the variables referenced in the template will not exist, and this will cause an exception in the admin UI.

I have just added default values to all the referenced variables, and wrapped the custom template includes in a conditional, so they will not be included if there is no need for it.