### PR TITLE
NGSTACK-992 prepare admin UI extra bundle for ibexa v5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1']
+        php: ['8.3']
         phpunit: ['phpunit.xml']
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ composer.lock
 build
 studio.json
 .phpunit.cache
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 build
 studio.json
 .phpunit.cache
+.idea/

--- a/bundle/Resources/config/services/controllers.yaml
+++ b/bundle/Resources/config/services/controllers.yaml
@@ -1,16 +1,24 @@
 services:
     Netgen\Bundle\IbexaAdminUIExtraBundle\Controller\Content\UpdateAlwaysAvailable:
-        parent: Ibexa\Contracts\AdminUi\Controller\Controller
         arguments:
             - '@translator'
             - '@ibexa.api.service.content'
             - '@Netgen\Bundle\IbexaAdminUIExtraBundle\Form\FormFactory'
             - '@Ibexa\Core\Helper\TranslationHelper'
+        calls:
+            - [setContainer , ['@Psr\Container\ContainerInterface']]
+        tags:
+            - controller.service_arguments
+            - container.service_subscriber
 
     Netgen\Bundle\IbexaAdminUIExtraBundle\Controller\Queues:
-        parent: Ibexa\Contracts\AdminUi\Controller\Controller
         arguments:
             $transportLocator: '@messenger.receiver_locator'
             $queuesEnabled: '%netgen_ibexa_admin_ui_extra.queues.enabled%'
             $allowedTransports: '%netgen_ibexa_admin_ui_extra.queues.transports%'
             $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+        calls:
+            - [setContainer , ['@Psr\Container\ContainerInterface']]
+        tags:
+            - controller.service_arguments
+            - container.service_subscriber

--- a/bundle/Resources/views/queues/list.html.twig
+++ b/bundle/Resources/views/queues/list.html.twig
@@ -2,6 +2,8 @@
 
 {% trans_default_domain 'netgen_ibexa_admin_ui_extra' %}
 
+{% block title %}{{ 'queues.title'|trans|desc('Queues') }}{% endblock %}
+
 {% block breadcrumbs %}
     {% include '@ibexadesign/ui/breadcrumbs.html.twig' with { items: [
         { value: 'breadcrumb.admin'|trans(domain='messages')|desc('Admin') },

--- a/bundle/Resources/views/themes/ngadmin/content/draft/draft_list.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content/draft/draft_list.html.twig
@@ -1,0 +1,3 @@
+{% extends '@admin/content/draft/draft_list.html.twig' %}
+
+{% block title %}{{ 'drafts.title'|trans|desc('Drafts') }}{% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,12 @@
         }
     ],
     "require": {
-        "ibexa/admin-ui": "^4.6"
+        "ibexa/admin-ui": "^5.0.2"
     },
     "require-dev": {
-        "netgen/ibexa-site-api": "^6.1",
-        "ibexa/graphql": "^4.5",
+        "ibexa/graphql": "^5.0.2",
         "phpunit/phpunit": "^10",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1"
+        "matthiasnoback/symfony-dependency-injection-test": "^6.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Main changes are that I updated the dependencies in `composer.json` file to support Ibexa v5 and modified the `controllers.yaml` file to exactly pass the `ContainerInterface` class to `AbstractController::setContainer()` method. 

Apparently, Symfony 7 has some stricter requirements about autowiring, and that's why there are the two tags added for each controller here - `controller.service_arguments` and `container.service_subscriber`.

In adminUI, when you go to **Queues** and **Drafts** options (in the left menu), I have fixed the tab title that is shown. 